### PR TITLE
Fix build and test.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,6 +23,12 @@ AC_PROG_INSTALL
 AC_PROG_LIBTOOL
 AC_PROG_MAKE_SET
 
+# Check for git
+AC_CHECK_PROGS(GIT, [git], "no")
+if test "x$GIT" = "xno"; then
+	AC_MSG_ERROR([git not found])
+fi
+
 # Check for rst utilities
 AC_CHECK_PROGS(RST2MAN, [rst2man rst2man.py], "no")
 if test "x$RST2MAN" = "xno"; then

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,16 +1,16 @@
-AM_CPPFLAGS = @VMOD_INCLUDES@ -Wall -Werror -Imruby/include -lm
+AM_CPPFLAGS = @VMOD_INCLUDES@ -Wall -I$(abs_srcdir)/mruby/include
 
 vmoddir = @VMOD_DIR@
 vmod_LTLIBRARIES = libvmod_mruby.la
 
+LIBMRUBY = $(srcdir)/mruby/build/host/lib/libmruby.a
 libvmod_mruby_la_LDFLAGS = -module -export-dynamic -avoid-version -shared -Imruby -Imruby/include -lm
-libvmod_mruby_la_LIBADD = $(top_srcdir)/src/mruby/build/host/lib/libmruby.a
+libvmod_mruby_la_LIBADD = $(LIBMRUBY)
 
 libvmod_mruby_la_SOURCES = \
 	vmod_mruby.c  \
 	vmod_class.h \
 	vmod_class.c
-	
 
 nodist_libvmod_mruby_la_SOURCES = \
 	vcc_if.c \
@@ -30,6 +30,16 @@ $(top_srcdir)/src/tests/*.vtc: libvmod_mruby.la
 	@VARNISHTEST@ -Dvarnishd=@VARNISHD@ -Dvmod_topbuild=$(abs_top_builddir) $@
 
 check: $(VMOD_TESTS)
+
+$(srcdir)/vmod_mruby.c: $(srcdir)/mruby
+$(srcdir)/vmod_class.c: $(srcdir)/mruby
+
+MRUBY_CONFIG_FILE = $(abs_top_srcdir)/build_config.rb
+$(LIBMRUBY): $(srcdir)/mruby $(MRUBY_CONFIG_FILE)
+	MRUBY_CONFIG=$(MRUBY_CONFIG_FILE) $(abs_srcdir)/mruby/minirake -C $(abs_srcdir)/mruby all
+
+$(srcdir)/mruby:
+	@GIT@ clone --depth 1 git://github.com/mruby/mruby.git
 
 EXTRA_DIST = \
 	vmod_mruby.vcc \

--- a/src/tests/test01.vtc
+++ b/src/tests/test01.vtc
@@ -9,7 +9,7 @@ varnish v1 -vcl+backend {
 	import mruby from "${vmod_topbuild}/src/.libs/libvmod_mruby.so";
 
 	sub vcl_deliver {
-		set resp.http.hello = mruby.hello("World");
+		set resp.http.hello = mruby.exec("'Hello, World'");
 	}
 } -start
 


### PR DESCRIPTION
Download mruby with git (close #1).
Using latest mruby with shallow clone.
Travis-CI should work with this pull request.

In `mruby.exec` string conversion may cause segmentation fault,
since `mrb_load_string` will return `mrb_undef_value()` on script compile failure.
